### PR TITLE
Make all python scripts use '/usr/bin/env python2'

### DIFF
--- a/fonts/gregoria2gregorio.py
+++ b/fonts/gregoria2gregorio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # coding=utf-8
 
 #Python fontforge script to build a square notation font.


### PR DESCRIPTION
Uniformity perhaps?
